### PR TITLE
Add ansi colors for intergared terminal

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -8,10 +8,13 @@ const lightBlue = ( alpha = '' ) => `99dbff${alpha}`
 const orange = ( alpha = '' ) => `de935f${alpha}`
 const teal = '8abeb7'
 
+const black = '242e33'
+const gray = '333333'
+
 const base = {
   themeLabel: 'Hybrid Next',
   settings: {
-    background: '242e33',
+    background: black,
     invisibles: lightGray('26'),
     lineHighlight: lightBlue('0a'),
     selection: lightBlue('26'),
@@ -21,6 +24,8 @@ const base = {
     orderedList: greenYellow('aa'),
     unorderedList: greenYellow('dd'),
   },
+  black,
+  gray,
   grayBlue: '6c7a80',
   greenYellow: greenYellow(),
   lightBlue: lightBlue(),
@@ -29,10 +34,15 @@ const base = {
   orange: orange(),
   orange2: orange('bb'), // Function arguments
   lime: 'a6e22e',
+  green: 'b5bd68',
+  lightGreen: '8c9440',
   blue: '81a2be',
   purple: 'b294bb',
+  darkPurple: '85678f',
   pink: 'f92672', // This is base for `storage` but gets overriden
   red: 'cc6666',
+  darkRed: 'a54242',
+  cyan: '5e8d87',
   teal,
   white: 'f8f8f0',
   yellow: 'f0c674',
@@ -47,7 +57,7 @@ const grayBg = Object.assign(
       {},
       base.settings,
       {
-        background: '333333',
+        background: gray,
         invisibles: lightGray('46'),
       }
     ),

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -34,8 +34,8 @@ const base = {
   orange: orange(),
   orange2: orange('bb'), // Function arguments
   lime: 'a6e22e',
-  green: 'b5bd68',
-  lightGreen: '8c9440',
+  green: '8c9440',
+  lightGreen: 'b5bd68',
   blue: '81a2be',
   purple: 'b294bb',
   darkPurple: '85678f',

--- a/src/template.tmTheme
+++ b/src/template.tmTheme
@@ -23,6 +23,38 @@
         <string>#{settings.lineHighlight}</string>
         <key>selection</key>
         <string>#{settings.selection}</string>
+        <key>ansiBlack</key>
+        <string>#{black}</string>
+        <key>ansiBrightBlack</key>
+        <string>#{gray}</string>
+        <key>ansiRed</key>
+        <string>#{darkRed}</string>
+        <key>ansiBrightRed</key>
+        <string>#{red}</string>
+        <key>ansiGreen</key>
+        <string>#{green}</string>
+        <key>ansiBrightGreen</key>
+        <string>#{lightGreen}</string>
+        <key>ansiYellow</key>
+        <string>#{orange}</string>
+        <key>ansiBrightYellow</key>
+        <string>#{yellow}</string>
+        <key>ansiBlue</key>
+        <string>#{blue}</string>
+        <key>ansiBrightBlue</key>
+        <string>#{lightBlue}</string>
+        <key>ansiMagenta</key>
+        <string>#{darkPurple}</string>
+        <key>ansiBrightMagenta</key>
+        <string>#{purple}</string>
+        <key>ansiCyan</key>
+        <string>#{cyan}</string>
+        <key>ansiBrightCyan</key>
+        <string>#{teal}</string>
+        <key>ansiWhite</key>
+        <string>#{grayBlue}</string>
+        <key>ansiBrightWhite</key>
+        <string>#{lightGray}</string>
       </dict>
     </dict>
     <dict>


### PR DESCRIPTION
VSCode supports the ansi colors https://github.com/Microsoft/vscode/pull/13169

### before
![image](https://user-images.githubusercontent.com/2010175/30245517-780e4516-9617-11e7-8941-58f1a7746244.png)

### after
![image](https://user-images.githubusercontent.com/2010175/30245550-174040a8-9618-11e7-8fd9-863e560105c1.png)
