### PR TITLE
Add support for interpolated variables in C#

### DIFF
--- a/src/template.tmTheme
+++ b/src/template.tmTheme
@@ -1117,6 +1117,21 @@
         <string>#{lightBlue}</string>
       </dict>
     </dict>
+    <dict>
+      <key>name</key>
+      <string>C# String Interpolation</string>
+      <key>scope</key>
+      <string>
+        meta.interpolation.cs variable.other.object.cs,
+        meta.interpolation.cs variable.other.object.property.cs,
+        meta.interpolation.cs variable.other.readwrite.cs
+      </string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#{lightGray}</string>
+      </dict>
+    </dict>
   </array>
   <key>uuid</key>
   <string>d8d5e82e-3d5b-46b5-b38e-8c841c21347d</string>


### PR DESCRIPTION
First off, thanks for bringing this theme to VS Code :+1:

I noticed that string-interpolated variables in C# were displaying with the same colour as the rest of the string, making them difficult to spot when looking through strings. It actually gave me some trouble when I was trying to debug something and didn't spot a variable that was being interpolated into a string!

This PR makes variables inside the interpolated string display with same light-grey value as per normal variables, making them easier to see and read.

Before:
![image](https://user-images.githubusercontent.com/395415/46923994-81a5b980-d06b-11e8-83a4-89e997861190.png)

After:
![image](https://user-images.githubusercontent.com/395415/46923996-94b88980-d06b-11e8-9825-b377ef8cffd4.png)